### PR TITLE
Correct README to link to http://haskellstack.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 **This project is unmaintained!**
-Haskeleton is now available as a [Stack](haskellstack.org) template.
+Haskeleton is now available as a [Stack](http://haskellstack.org) template.
 Getting started with the new version is easy:
 
 ``` sh


### PR DESCRIPTION
Without the protocol `http://` browsers think this is a relative link.
